### PR TITLE
PEP668 error: externally-managed-environment修正

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           fetch-depth: 0
       - name: Pip install
-        run: pip install -r requirements.txt
+        run: pip install --break-system-packages -r requirements.txt
       - name: Run script
         run: python get_stock_prices.py


### PR DESCRIPTION
使い捨てのGithub Actions環境なので--break-system-packagesを許容する
